### PR TITLE
Remove `run` from `npm run install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a project template for svelte draft apps, and it's adapted from https://
 ## Run
 
 ```
-> npm run install
+> npm install
 > npm run dev
 ```
 


### PR DESCRIPTION
Noticed there wasn't an install script in package.json.  Not sure if that was intentional?